### PR TITLE
Skip iterating over children when there aren't any

### DIFF
--- a/pygtrie.py
+++ b/pygtrie.py
@@ -139,6 +139,11 @@ class _Node(object):
         """
         def children():
             """Recursively traverses all of node's children."""
+
+            # Don't iterate over children if there aren't any
+            if not self.children:
+                return
+
             for step, node in iteritems(self.children):
                 yield node.traverse(node_factory, path_conv, path + [step],
                                     iteritems)


### PR DESCRIPTION
In case of StringTrie with sorting enabled, it was observed that filesystem paths that correspond to a directory when entered as a key in the Trie without any children lead to errors in the traverse method. This is due to the fact that such entries usually have a False value at the leaf nodes and thus, have no children. Due to this, when we have sorting enabled, we get the following error:

`AttributeError: '_NoChildren' object has no attribute 'sorted_items'`

If we add a check to skip iteration in the nested children() method, then we can get these paths in the output as well.