### PR TITLE
Import collections.abc instead of collections

### DIFF
--- a/pygtrie.py
+++ b/pygtrie.py
@@ -39,7 +39,10 @@ __author__ = 'Michal Nazarewicz <mina86@mina86.com>'
 __copyright__ = 'Copyright 2014 Google Inc.'
 
 
-import collections as _collections
+try:
+    import collections.abc as _collections
+except ImportError:
+    import collections as _collections
 
 # Python 2.x and 3.x compatibility stuff
 if hasattr(dict, 'iteritems'):


### PR DESCRIPTION
Importing ABCs from collectiions is deprecated since Python 3.3 and it
will stop working in 3.9. Use import collections.abc instead